### PR TITLE
fix WECHAT_WEBGL_BACKEND_NAME

### DIFF
--- a/src/plugin/utils/wechat_platform.ts
+++ b/src/plugin/utils/wechat_platform.ts
@@ -121,7 +121,7 @@ export function initWebGL(
     }
     tf.webgl.setWebGLContext(1, gl);
     try {
-      tf.registerBackend('wechat-webgl', () => {
+      tf.registerBackend(WECHAT_WEBGL_BACKEND_NAME, () => {
         const context = new tf.webgl.GPGPUContext(gl);
         return new tf.webgl.MathBackendWebGL(context);
       }, BACKEND_PRIORITY);


### PR DESCRIPTION
The latest version of wechat minapp needs to re register webgl elements every time, so i found an error caused by carelessness here.

微信小程序中最新版需要每次重新注册WebGL元素，所以发现了这里的一处不严谨导致的错误。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-wechat/37)
<!-- Reviewable:end -->
