### PR TITLE
allow user to specify the webgl backend name

### DIFF
--- a/src/plugin/test/wechat_platform_test.ts
+++ b/src/plugin/test/wechat_platform_test.ts
@@ -150,18 +150,13 @@ describe('setupWechatPlatform', () => {
     expect(tf.ENV.global.atob).toBeDefined();
   });
 
-  it('should set tf backend to test-webgl', () => {
+  it('should set tf backend to wechat-webgl', () => {
     setupWechatPlatform(config);
     expect(tf.getBackend()).toEqual(WECHAT_WEBGL_BACKEND_NAME);
   });
 
-  it('should set tf backend to wechat-webgl', () => {
-    const configWithBackendName = {
-      fetchFunc,
-      tf,
-      canvas,
-      backendName
-    };
+  it('should set tf backend to test-webgl', () => {
+    const configWithBackendName = {fetchFunc, tf, canvas, backendName};
     setupWechatPlatform(configWithBackendName);
     expect(tf.getBackend()).toEqual(backendName);
   });

--- a/src/plugin/test/wechat_platform_test.ts
+++ b/src/plugin/test/wechat_platform_test.ts
@@ -48,6 +48,7 @@ const gl = {};
 const canvas = {
   getContext: () => gl
 };
+const backendName = 'test-webgl';
 const config = {
   fetchFunc,
   tf,
@@ -149,9 +150,20 @@ describe('setupWechatPlatform', () => {
     expect(tf.ENV.global.atob).toBeDefined();
   });
 
-  it('should set tf backend to wechat-webgl', () => {
+  it('should set tf backend to test-webgl', () => {
     setupWechatPlatform(config);
     expect(tf.getBackend()).toEqual(WECHAT_WEBGL_BACKEND_NAME);
+  });
+
+  it('should set tf backend to wechat-webgl', () => {
+    const configWithBackendName = {
+      fetchFunc,
+      tf,
+      canvas,
+      backendName
+    };
+    setupWechatPlatform(configWithBackendName);
+    expect(tf.getBackend()).toEqual(backendName);
   });
 
   it('should set the WEBGL context', () => {


### PR DESCRIPTION
In the latest version of wechat mini program, the offscreen canvas might be destroyed after the page is disposed. Update the plugin API to allow user to set the webgl backend name, so it can re-initialize the backend as needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-wechat/38)
<!-- Reviewable:end -->
