### PR TITLE
support to save model into binary files

### DIFF
--- a/demo/mobilenet/app.js
+++ b/demo/mobilenet/app.js
@@ -22,7 +22,10 @@ const plugin = requirePlugin('tfjsPlugin');
 const ENABLE_DEBUG = true;
 //app.js
 App({
-  globalData: {localStorageIO: plugin.localStorageIO},
+  globalData: {
+    localStorageIO: plugin.localStorageIO,
+    fileStorageIO: plugin.fileStorageIO,
+  },
   onLaunch: function () {
     plugin.configPlugin({
       fetchFunc: fetchWechat.fetchFunc(),

--- a/demo/mobilenet/model/mobilenet.ts
+++ b/demo/mobilenet/model/mobilenet.ts
@@ -21,7 +21,8 @@ const GOOGLE_CLOUD_STORAGE_DIR =
   'https://tfhub.dev/google/tfjs-model/imagenet/';
 const MODEL_FILE_URL = 'mobilenet_v2_050_224/feature_vector/3/default/1';
 const PREPROCESS_DIVISOR = 255 / 2;
-const LOCAL_STORAGE_KEY = 'mobilenet_model';
+const STORAGE_KEY = 'mobilenet_model';
+
 export interface TopKValue {
   label: string;
   value: number;
@@ -31,14 +32,16 @@ export class MobileNet {
   constructor() { }
 
   async load() {
-    const localStorageHandler = getApp().globalData.localStorageIO(LOCAL_STORAGE_KEY);
+    // const storageHandler = getApp().globalData.localStorageIO(STORAGE_KEY); // save model into local storage as base64 string
+    const storageHandler = getApp().globalData.fileStorageIO(STORAGE_KEY); // save model into files (weight binary)
+
     try {
-      this.model = await tfc.loadGraphModel(localStorageHandler);
+      this.model = await tfc.loadGraphModel(storageHandler);
     } catch (e) {
       this.model =
         await tfc.loadGraphModel(GOOGLE_CLOUD_STORAGE_DIR + MODEL_FILE_URL,
           { fromTFHub: true });
-      this.model.save(localStorageHandler);
+      this.model.save(storageHandler);
     }
   }
 

--- a/demo/mobilenet/model/mobilenet.ts
+++ b/demo/mobilenet/model/mobilenet.ts
@@ -32,8 +32,10 @@ export class MobileNet {
   constructor() { }
 
   async load() {
-    // const storageHandler = getApp().globalData.localStorageIO(STORAGE_KEY); // save model into local storage as base64 string
-    const storageHandler = getApp().globalData.fileStorageIO(STORAGE_KEY); // save model into files (weight binary)
+    // save model into local storage as base64 string
+    // const storageHandler = getApp().globalData.localStorageIO(STORAGE_KEY);
+    // save model into files (weight binary)
+    const storageHandler = getApp().globalData.fileStorageIO(STORAGE_KEY);
 
     try {
       this.model = await tfc.loadGraphModel(storageHandler);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "karma-jasmine": "~2.0.1",
     "karma-typescript": "~4.0.0",
     "karma-typescript-es6-transform": "4.0.0",
-    "miniprogram-api-typings": "^2.6.5-2",
+    "miniprogram-api-typings": "^2.10.1-1",
     "miniprogram-simulate": "^1.0.1",
     "ncp": "2.0.0",
     "path": "0.12.7",

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -17,3 +17,4 @@
 export { configPlugin } from './api/config';
 export { SystemConfig } from './utils/wechat_platform';
 export { localStorageIO } from './utils/local_storage';
+export { fileStorageIO } from './utils/file_storage';

--- a/src/plugin/package.json
+++ b/src/plugin/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@tensorflow/tfjs-core": "1.5.2",
-    "miniprogram-api-typings": "2.10.0-1",
+    "miniprogram-api-typings": "2.10.1-1",
     "typescript": "^3.3.3333"
   }
 }

--- a/src/plugin/test/file_storage_test.ts
+++ b/src/plugin/test/file_storage_test.ts
@@ -1,0 +1,160 @@
+import * as tf from '@tensorflow/tfjs-core';
+import { fileStorageIO } from '../utils/file_storage';
+
+class FakeFileSystemManager {
+  private _storage: {};
+  constructor(storage) {
+    this._storage = storage;
+  }
+
+  unlink({ filePath, success, fail }) {
+    const res = delete this._storage[filePath];
+    success({ data: res });
+  }
+
+  readFile({ filePath, encoding, success, fail }) {
+    success({ data: this._storage[filePath] });
+  }
+
+  writeFile({ filePath, data, encoding, success, fail }) {
+    this._storage[filePath] = data;
+    success({ data: this._storage[filePath] });
+  }
+
+  access({ path, success, fail }) {
+    if (this._storage[path]) {
+      success();
+    } else {
+      fail();
+    }
+  }
+
+  mkdir({ dirPath, recursive, success, fail }) {
+    success();
+  }
+}
+
+describe('fileStorageIO', () => {
+  // Test data.
+  const modelTopology1: {} = {
+    'class_name': 'Sequential',
+    'keras_version': '2.1.4',
+    'config': [{
+      'class_name': 'Dense',
+      'config': {
+        'kernel_initializer': {
+          'class_name': 'VarianceScaling',
+          'config': {
+            'distribution': 'uniform',
+            'scale': 1.0,
+            'seed': null,
+            'mode': 'fan_avg'
+          }
+        },
+        'name': 'dense',
+        'kernel_constraint': null,
+        'bias_regularizer': null,
+        'bias_constraint': null,
+        'dtype': 'float32',
+        'activation': 'linear',
+        'trainable': true,
+        'kernel_regularizer': null,
+        'bias_initializer': { 'class_name': 'Zeros', 'config': {} },
+        'units': 1,
+        'batch_input_shape': [null, 3],
+        'use_bias': true,
+        'activity_regularizer': null
+      }
+    }],
+    'backend': 'tensorflow'
+  };
+
+  const weightSpecs1: tf.io.WeightsManifestEntry[] = [
+    {
+      name: 'dense/kernel',
+      shape: [3, 1],
+      dtype: 'float32',
+    },
+    {
+      name: 'dense/bias',
+      shape: [1],
+      dtype: 'float32',
+    }
+  ];
+  const weightData1 = new ArrayBuffer(16);
+
+  const artifacts1: tf.io.ModelArtifacts = {
+    modelTopology: modelTopology1,
+    weightSpecs: weightSpecs1,
+    weightData: weightData1,
+    format: 'layers-model',
+    generatedBy: 'TensorFlow.js v0.0.0',
+    convertedBy: null
+  };
+
+  const artifactsV0: tf.io.ModelArtifacts = {
+    modelTopology: modelTopology1,
+    weightSpecs: weightSpecs1,
+    weightData: weightData1
+  };
+
+  let storage = {};
+  let fileSystemManager: FakeFileSystemManager;
+
+  beforeEach(() => {
+    storage = {};
+    fileSystemManager = new FakeFileSystemManager(storage);
+    if (!wx.getFileSystemManager) {
+      wx.getFileSystemManager = () => null; // miniprogram-simulate don't have it
+    }
+    spyOn(wx, 'getFileSystemManager').and.callFake(() => {
+      return fileSystemManager;
+    });
+  });
+
+  it('constructs an IOHandler', async () => {
+    const handler = fileStorageIO('foo');
+    expect(typeof handler.load).toBe('function');
+    expect(typeof handler.save).toBe('function');
+  });
+
+  it('save returns a SaveResult', async () => {
+    const handler = fileStorageIO('FooModel');
+    const result = await handler.save(artifacts1);
+    expect(result.modelArtifactsInfo).toBeDefined();
+    expect(result.modelArtifactsInfo).not.toBeNull();
+
+    expect(result.modelArtifactsInfo.modelTopologyType).toBe('JSON');
+    expect(result.modelArtifactsInfo.weightDataBytes).toBe(16);
+  });
+
+  it('Save-load round trip succeeds', async () => {
+    const handler = fileStorageIO('FooModel');
+    await handler.save(artifacts1);
+
+    const handler2 = fileStorageIO('FooModel');
+    const loaded = await handler2.load();
+
+    expect(loaded.modelTopology).toEqual(modelTopology1);
+    expect(loaded.weightSpecs).toEqual(weightSpecs1);
+    expect(loaded.weightData).toEqual(weightData1);
+    expect(loaded.format).toEqual('layers-model');
+    expect(loaded.generatedBy).toEqual('TensorFlow.js v0.0.0');
+    expect(loaded.convertedBy).toEqual(null);
+  });
+
+  it('Save-load round trip succeeds: v0 format', async () => {
+    const handler1 = fileStorageIO('FooModel');
+    await handler1.save(artifactsV0);
+
+    const handler2 = fileStorageIO('FooModel');
+    const loaded = await handler2.load();
+
+    expect(loaded.modelTopology).toEqual(modelTopology1);
+    expect(loaded.weightSpecs).toEqual(weightSpecs1);
+    expect(loaded.weightData).toEqual(weightData1);
+    expect(loaded.format).toEqual(undefined);
+    expect(loaded.generatedBy).toEqual(undefined);
+    expect(loaded.convertedBy).toEqual(undefined);
+  });
+});

--- a/src/plugin/utils/file_storage.ts
+++ b/src/plugin/utils/file_storage.ts
@@ -1,0 +1,217 @@
+import { io } from '@tensorflow/tfjs-core';
+import { getModelArtifactsInfoForJSON } from './model_artifacts';
+
+type StoragePaths = {
+  info: string,
+  modelArtifactsWithoutWeights: string,
+  weightData: string,
+};
+
+const PATH_SEPARATOR = '/';
+const PATH_PREFIX = 'tensorflowjs_models';
+const INFO_SUFFIX = 'info.json';
+const MODEL_SUFFIX = 'model_without_weight.json';
+const WEIGHT_DATA_SUFFIX = 'weight_data';
+
+// @ts-ignore // wx.env not defined in wx type
+const MODEL_PATH = [wx.env.USER_DATA_PATH, PATH_PREFIX].join(PATH_SEPARATOR);
+
+function getModelPaths(prefix: string): StoragePaths {
+  return {
+    info: [MODEL_PATH, `${prefix}_${INFO_SUFFIX}`].join(PATH_SEPARATOR),
+    modelArtifactsWithoutWeights:
+      [MODEL_PATH, `${prefix}_${MODEL_SUFFIX}`].join(PATH_SEPARATOR),
+    weightData: [MODEL_PATH, `${prefix}_${WEIGHT_DATA_SUFFIX}`].join(PATH_SEPARATOR),
+  };
+}
+
+function removeFile(filePath: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const fsm = wx.getFileSystemManager();
+    fsm.unlink({
+      filePath,
+      success: (res) => {
+        resolve(res);
+      },
+      fail: (res) => {
+        reject(new Error(res.errMsg));
+      }
+    });
+  });
+}
+
+async function removeFileIfExist(filePath: string): Promise<any> {
+  try {
+    await removeFile(filePath);
+  } catch (e) {
+    // ignore error
+  }
+}
+
+function readFile(filePath: string, encoding?: any): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const fsm = wx.getFileSystemManager();
+    fsm.readFile({
+      filePath,
+      encoding,
+      success: (res) => {
+        if (res.data) {
+          resolve(res.data);
+          return;
+        }
+        reject(new Error('Empty File'));
+      },
+      fail: (res) => {
+        reject(new Error(res.errMsg));
+      }
+    });
+  });
+}
+
+function writeFile(filePath: string, data: any, encoding: any = 'binary'): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const fsm = wx.getFileSystemManager();
+    fsm.writeFile({
+      filePath,
+      data,
+      encoding,
+      success: (res) => {
+        resolve(res);
+      },
+      fail: (res) => {
+        reject(new Error(res.errMsg));
+      }
+    });
+  });
+}
+
+function mkdir(dirPath: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const fsm = wx.getFileSystemManager();
+    fsm.access({
+      path: dirPath,
+      success: () => {
+        resolve();
+      },
+      fail: () => {
+        fsm.mkdir({
+          dirPath,
+          recursive: true,
+          success: (res) => {
+            resolve(res);
+          },
+          fail: (res) => {
+            reject(new Error(res.errMsg));
+          }
+        });
+      }
+    });
+  });
+}
+
+class FileStorageHandler implements io.IOHandler {
+  protected readonly paths: StoragePaths;
+  protected readonly prefix: string;
+
+  constructor(prefix) {
+    if (prefix == null || !prefix) {
+      throw new Error('prefix must not be null, undefined or empty.');
+    }
+    this.prefix = prefix;
+    this.paths = getModelPaths(this.prefix);
+  }
+
+  /**
+   * Save model artifacts to File
+   *
+   * @param modelArtifacts The model artifacts to be stored.
+   * @returns An instance of SaveResult.
+   */
+  async save(modelArtifacts: io.ModelArtifacts): Promise<io.SaveResult> {
+    if (modelArtifacts.modelTopology instanceof ArrayBuffer) {
+      throw new Error(
+        'AsyncStorageHandler.save() does not support saving model topology ' +
+        'in binary format.');
+    } else {
+      // We save three items separately for each model,
+      // a ModelArtifactsInfo, a ModelArtifacts without weights
+      // and the model weights.
+      const modelArtifactsInfo =
+        getModelArtifactsInfoForJSON(modelArtifacts);
+      const { weightData, ...modelArtifactsWithoutWeights } = modelArtifacts;
+      // const weights = splitString(fromByteArray(new Uint8Array(weightData)),
+      //   800 * 1024);
+
+      try {
+        await mkdir(MODEL_PATH);
+        await removeFileIfExist(this.paths.info);
+        await writeFile(this.paths.info, JSON.stringify(modelArtifactsInfo), 'utf-8');
+        await removeFileIfExist(this.paths.modelArtifactsWithoutWeights);
+        await writeFile(
+          this.paths.modelArtifactsWithoutWeights,
+          JSON.stringify(modelArtifactsWithoutWeights),
+          'utf-8'
+        );
+        await removeFileIfExist(this.paths.weightData);
+        await writeFile(this.paths.weightData, weightData);
+        return { modelArtifactsInfo };
+      } catch (err) {
+        // If saving failed, clean up all items saved so far.
+        await removeFileIfExist(this.paths.info)
+        await removeFileIfExist(this.paths.modelArtifactsWithoutWeights)
+        await removeFileIfExist(this.paths.weightData)
+
+        throw new Error(err);
+      }
+    }
+  }
+
+  /**
+   * Load a model from files.
+   *
+   * @returns The loaded model (if loading succeeds).
+   */
+  async load(): Promise<io.ModelArtifacts> {
+    const info =
+      JSON.parse(await readFile(this.paths.info, 'utf-8'));
+    if (info == null) {
+      throw new Error(
+        `In file storage, there is no model with name '${this.prefix}'`);
+    }
+
+    if (info.modelTopologyType !== 'JSON') {
+      throw new Error(
+        'fileStorage does not support loading non-JSON model ' +
+        'topology yet.');
+    }
+
+    const modelArtifacts =
+      JSON.parse(await readFile(this.paths.modelArtifactsWithoutWeights, 'utf-8'));
+
+    // load weight data
+    modelArtifacts.weightData = await readFile(this.paths.weightData);
+    return modelArtifacts;
+  }
+}
+
+/**
+ * Factory function for FileStorage IOHandler.
+ *
+ * This `IOHandler` supports both `save` and `load`.
+ *
+ * For each model's saved artifacts, three items are saved to user files.
+ *   - `${PATH_PREFIX}/${prefix}/info.json`: Contains meta-info about the
+ *     model, such as date saved, type of the topology, size in bytes, etc.
+ *   - `${PATH_PREFIX}/${prefix}/model_without_weight.json`: The topology,
+ *     weights_specs and all other information about the model except for the
+ *     weights.
+ *   - `${PATH_PREFIX}/${prefix}/weight_data`: Concatenated binary
+ *     weight values, stored as binary.
+ *
+ * @param prefix A unique identifier for the model to be saved. Must be a
+ *   non-empty string.
+ * @returns An instance of `IOHandler`
+ */
+export function fileStorageIO(prefix: string): io.IOHandler {
+  return new FileStorageHandler(prefix);
+}

--- a/src/plugin/utils/file_storage.ts
+++ b/src/plugin/utils/file_storage.ts
@@ -1,3 +1,7 @@
+/**
+ *  Save and load model into miniprogram file system
+ *  FileSystemManager https://developers.weixin.qq.com/miniprogram/dev/api/file/wx.getFileSystemManager.html
+ */
 import { io } from '@tensorflow/tfjs-core';
 import { getModelArtifactsInfoForJSON } from './model_artifacts';
 
@@ -13,6 +17,8 @@ const INFO_SUFFIX = 'info.json';
 const MODEL_SUFFIX = 'model_without_weight.json';
 const WEIGHT_DATA_SUFFIX = 'weight_data';
 
+// get user path
+// https://developers.weixin.qq.com/miniprogram/dev/api/base/env/env.html
 function getUserDataPath() {
   if (!wx.env) {
     wx.env = {
@@ -21,7 +27,6 @@ function getUserDataPath() {
   }
   return wx.env.USER_DATA_PATH;
 }
-
 const MODEL_PATH = [getUserDataPath(), PATH_PREFIX].join(PATH_SEPARATOR);
 
 function getModelPaths(prefix: string): StoragePaths {
@@ -33,8 +38,12 @@ function getModelPaths(prefix: string): StoragePaths {
   };
 }
 
-// Make remove file as promise
-// This function will ignore removed error (file not existed)
+/**
+ * Make remove file
+ * This function will ignore removed error (file not existed)
+ * https://developers.weixin.qq.com/miniprogram/dev/api/file/FileSystemManager.unlink.html
+ * @param filePath the file path to be removed
+ */
 // tslint:disable-next-line:no-any
 function removeFile(filePath: string): Promise<any> {
   return new Promise((resolve, reject) => {
@@ -51,6 +60,12 @@ function removeFile(filePath: string): Promise<any> {
   });
 }
 
+/**
+ * Read file
+ * https://developers.weixin.qq.com/miniprogram/dev/api/file/FileSystemManager.readFile.html
+ * @param filePath the file path
+ * @param encoding the encoding, default reture ArrayBuffer if undefined
+ */
 // tslint:disable-next-line:no-any
 function readFile(filePath: string, encoding?: any): Promise<any> {
   return new Promise((resolve, reject) => {
@@ -72,6 +87,13 @@ function readFile(filePath: string, encoding?: any): Promise<any> {
   });
 }
 
+/**
+ * Write file
+ * https://developers.weixin.qq.com/miniprogram/dev/api/file/FileSystemManager.writeFile.html
+ * @param filePath the file path
+ * @param data data to save
+ * @param encoding  encoding
+ */
 // tslint:disable-next-line:no-any
 function writeFile(filePath: string, data: any, encoding: any = 'binary'): Promise<any> {
   return new Promise((resolve, reject) => {
@@ -147,8 +169,6 @@ class FileStorageHandler implements io.IOHandler {
       const modelArtifactsInfo =
         getModelArtifactsInfoForJSON(modelArtifacts);
       const { weightData, ...modelArtifactsWithoutWeights } = modelArtifacts;
-      // const weights = splitString(fromByteArray(new Uint8Array(weightData)),
-      //   800 * 1024);
 
       try {
         await mkdir(MODEL_PATH);

--- a/src/plugin/utils/file_storage.ts
+++ b/src/plugin/utils/file_storage.ts
@@ -13,8 +13,16 @@ const INFO_SUFFIX = 'info.json';
 const MODEL_SUFFIX = 'model_without_weight.json';
 const WEIGHT_DATA_SUFFIX = 'weight_data';
 
-// @ts-ignore // wx.env not defined in wx type
-const MODEL_PATH = [wx.env.USER_DATA_PATH, PATH_PREFIX].join(PATH_SEPARATOR);
+function getUserDataPath() {
+  if (!wx.env) {
+    wx.env = {
+      USER_DATA_PATH: 'http://usr'
+    };
+  }
+  return wx.env.USER_DATA_PATH;
+}
+
+const MODEL_PATH = [getUserDataPath(), PATH_PREFIX].join(PATH_SEPARATOR);
 
 function getModelPaths(prefix: string): StoragePaths {
   return {
@@ -27,6 +35,7 @@ function getModelPaths(prefix: string): StoragePaths {
 
 // Make remove file as promise
 // This function will ignore removed error (file not existed)
+// tslint:disable-next-line:no-any
 function removeFile(filePath: string): Promise<any> {
   return new Promise((resolve, reject) => {
     const fsm = wx.getFileSystemManager();
@@ -36,12 +45,13 @@ function removeFile(filePath: string): Promise<any> {
         resolve(res);
       },
       fail: (res) => {
-        resolve(null)
+        resolve(null);
       }
     });
   });
 }
 
+// tslint:disable-next-line:no-any
 function readFile(filePath: string, encoding?: any): Promise<any> {
   return new Promise((resolve, reject) => {
     const fsm = wx.getFileSystemManager();
@@ -62,6 +72,7 @@ function readFile(filePath: string, encoding?: any): Promise<any> {
   });
 }
 
+// tslint:disable-next-line:no-any
 function writeFile(filePath: string, data: any, encoding: any = 'binary'): Promise<any> {
   return new Promise((resolve, reject) => {
     removeFile(filePath).then(() => {
@@ -81,6 +92,7 @@ function writeFile(filePath: string, data: any, encoding: any = 'binary'): Promi
   });
 }
 
+// tslint:disable-next-line:no-any
 function mkdir(dirPath: string): Promise<any> {
   return new Promise((resolve, reject) => {
     const fsm = wx.getFileSystemManager();
@@ -150,9 +162,9 @@ class FileStorageHandler implements io.IOHandler {
         return { modelArtifactsInfo };
       } catch (err) {
         // If saving failed, clean up all items saved so far.
-        await removeFile(this.paths.info)
-        await removeFile(this.paths.modelArtifactsWithoutWeights)
-        await removeFile(this.paths.weightData)
+        await removeFile(this.paths.info);
+        await removeFile(this.paths.modelArtifactsWithoutWeights);
+        await removeFile(this.paths.weightData);
 
         throw new Error(err);
       }

--- a/src/plugin/utils/file_storage.ts
+++ b/src/plugin/utils/file_storage.ts
@@ -39,7 +39,6 @@ function getModelPaths(prefix: string): StoragePaths {
   };
 }
 
-/* tslint:disable:no-any */
 /**
  * Make remove file
  * This function will ignore removed error (file not existed)
@@ -50,7 +49,7 @@ function getModelPaths(prefix: string): StoragePaths {
 function removeFile(
   fsm: WechatMiniprogram.FileSystemManager,
   filePath: string,
-): Promise<any> {
+): Promise<WechatMiniprogram.GeneralCallbackResult | WechatMiniprogram.UnlinkFailCallbackResult> {
   return new Promise((resolve, reject) => {
     fsm.unlink({
       filePath,
@@ -75,8 +74,8 @@ function removeFile(
 function readFile(
   fsm: WechatMiniprogram.FileSystemManager,
   filePath: string,
-  encoding?: any
-): Promise<any> {
+  encoding?: 'utf-8',
+): Promise<string | ArrayBuffer> {
   return new Promise((resolve, reject) => {
     fsm.readFile({
       filePath,
@@ -106,9 +105,9 @@ function readFile(
 function writeFile(
   fsm: WechatMiniprogram.FileSystemManager,
   filePath: string,
-  data: any,
-  encoding: any = 'binary'
-): Promise<any> {
+  data: string | ArrayBuffer,
+  encoding: 'binary' | 'utf-8' = 'binary'
+): Promise<WechatMiniprogram.GeneralCallbackResult> {
   return new Promise((resolve, reject) => {
     removeFile(fsm, filePath).then(() => {
       fsm.writeFile({
@@ -134,7 +133,7 @@ function writeFile(
  */
 function mkdir(
   fsm: WechatMiniprogram.FileSystemManager, dirPath: string
-): Promise<any> {
+): Promise<WechatMiniprogram.GeneralCallbackResult> {
   return new Promise((resolve, reject) => {
     fsm.access({
       path: dirPath,
@@ -156,7 +155,6 @@ function mkdir(
     });
   });
 }
-// tslint:enable-next-line:no-any
 
 class FileStorageHandler implements io.IOHandler {
   protected readonly paths: StoragePaths;
@@ -222,7 +220,7 @@ class FileStorageHandler implements io.IOHandler {
    */
   async load(): Promise<io.ModelArtifacts> {
     const info =
-      JSON.parse(await readFile(this.fsm, this.paths.info, 'utf-8'));
+      JSON.parse((await readFile(this.fsm, this.paths.info, 'utf-8')) as string);
     if (info == null) {
       throw new Error(
         `In file storage, there is no model with name '${this.prefix}'`);
@@ -236,7 +234,7 @@ class FileStorageHandler implements io.IOHandler {
 
     const modelArtifacts =
       JSON.parse(
-        await readFile(this.fsm, this.paths.modelArtifactsWithoutWeights, 'utf-8')
+        (await readFile(this.fsm, this.paths.modelArtifactsWithoutWeights, 'utf-8')) as string
       );
 
     // load weight data

--- a/src/plugin/utils/local_storage.ts
+++ b/src/plugin/utils/local_storage.ts
@@ -17,6 +17,7 @@
 
 import { io } from '@tensorflow/tfjs-core';
 import { fromByteArray, toByteArray } from 'base64-js';
+import { getModelArtifactsInfoForJSON } from './model_artifacts';
 
 type StorageKeys = {
   info: string,
@@ -40,26 +41,6 @@ function getModelKeys(path: string): StorageKeys {
     weightData: [PATH_PREFIX, path, WEIGHT_DATA_SUFFIX].join(PATH_SEPARATOR),
     weightDataChunkSize:
       [PATH_PREFIX, path, WEIGHT_DATA_SIZE_SUFFIX].join(PATH_SEPARATOR)
-  };
-}
-/**
- * Populate ModelArtifactsInfo fields for a model with JSON topology.
- * @param modelArtifacts
- * @returns A ModelArtifactsInfo object.
- */
-function getModelArtifactsInfoForJSON(modelArtifacts: io.ModelArtifacts):
-  io.ModelArtifactsInfo {
-  if (modelArtifacts.modelTopology instanceof ArrayBuffer) {
-    throw new Error('Expected JSON model topology, received ArrayBuffer.');
-  }
-
-  return {
-    dateSaved: new Date(),
-    // TODO followup on removing this from the the interface
-    modelTopologyType: 'JSON',
-    weightDataBytes: modelArtifacts.weightData == null ?
-      0 :
-      modelArtifacts.weightData.byteLength,
   };
 }
 

--- a/src/plugin/utils/model_artifacts.ts
+++ b/src/plugin/utils/model_artifacts.ts
@@ -1,0 +1,22 @@
+import { io } from '@tensorflow/tfjs-core';
+
+/**
+ * Populate ModelArtifactsInfo fields for a model with JSON topology.
+ * @param modelArtifacts
+ * @returns A ModelArtifactsInfo object.
+ */
+export function getModelArtifactsInfoForJSON(modelArtifacts: io.ModelArtifacts):
+  io.ModelArtifactsInfo {
+  if (modelArtifacts.modelTopology instanceof ArrayBuffer) {
+    throw new Error('Expected JSON model topology, received ArrayBuffer.');
+  }
+
+  return {
+    dateSaved: new Date(),
+    // TODO followup on removing this from the the interface
+    modelTopologyType: 'JSON',
+    weightDataBytes: modelArtifacts.weightData == null ?
+      0 :
+      modelArtifacts.weightData.byteLength,
+  };
+}

--- a/src/plugin/yarn.lock
+++ b/src/plugin/yarn.lock
@@ -39,9 +39,10 @@ base64-js@1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
-miniprogram-api-typings@2.10.0-1:
-  version "2.10.0-1"
-  resolved "https://registry.yarnpkg.com/miniprogram-api-typings/-/miniprogram-api-typings-2.10.0-1.tgz#6abe6ce9221146c4c101f79d17b5f8de555078eb"
+miniprogram-api-typings@2.10.1-1:
+  version "2.10.1-1"
+  resolved "https://registry.npm.taobao.org/miniprogram-api-typings/download/miniprogram-api-typings-2.10.1-1.tgz#9a18404b5af370051eb78c24638dfeed0312c44d"
+  integrity sha1-mhhAS1rzcAUet4wkY43+7QMSxE0=
 
 node-fetch@~2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.7.tgz#522328de16470aa9f7c15b91e4b68616f425002a"
-  integrity sha512-RsXavYKMc0MOcCmOyD7HE8am1tWlDGXl0nJbsdib7ubmvMuH6KnrZ302eTYV7k1RMq+/ukkioJmCcw13hopuHQ==
+"@tensorflow/tfjs-core@1.5.2":
+  version "1.5.2"
+  resolved "https://registry.npm.taobao.org/@tensorflow/tfjs-core/download/@tensorflow/tfjs-core-1.5.2.tgz#df76752cf7c43987df1548fb69820935bd8215d7"
+  integrity sha1-33Z1LPfEOYffFUj7aYIJNb2CFdc=
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"
@@ -3099,10 +3099,10 @@ minipass@^2.2.1, minipass@^2.3.4:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-miniprogram-api-typings@^2.6.5-2:
-  version "2.6.5-2"
-  resolved "https://registry.yarnpkg.com/miniprogram-api-typings/-/miniprogram-api-typings-2.6.5-2.tgz#990e3e5b91074ba4306bf6b8173cf38b632b4d3f"
-  integrity sha512-P0NdPNfaCYL7E7w1VHhpYCeu6WcN7h3xejqwWv5jmqdTTdHda+EJKby1VNc49rPn/w45NiNJD5gHgeMHGlb9xA==
+miniprogram-api-typings@^2.10.1-1:
+  version "2.10.1-1"
+  resolved "https://registry.npm.taobao.org/miniprogram-api-typings/download/miniprogram-api-typings-2.10.1-1.tgz?cache=0&sync_timestamp=1581320186574&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fminiprogram-api-typings%2Fdownload%2Fminiprogram-api-typings-2.10.1-1.tgz#9a18404b5af370051eb78c24638dfeed0312c44d"
+  integrity sha1-mhhAS1rzcAUet4wkY43+7QMSxE0=
 
 miniprogram-compiler@latest:
   version "0.1.0"


### PR DESCRIPTION
As localStorageIO, fileStorageIO saves model into files.

**Advantages**:
fileStorageIO save weight with binary which is smaller than base64 string in localStorageIO.

Support to save about 10MB weight binary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-wechat/50)
<!-- Reviewable:end -->
